### PR TITLE
fix: typo `composition, analysis` to `composition analysis`

### DIFF
--- a/.github/steps/1-enable-secret-scanning.md
+++ b/.github/steps/1-enable-secret-scanning.md
@@ -19,7 +19,7 @@ The GitHub Docs provides a list of [all supported patterns](https://docs.github.
 
 Secret protection is a powerful tool which allows teams to identify these plain-text credentials, remove them, and create rules to prevent them from being written to GitHub in the first place.
 
-Secret protection is available **for free for public repositories** on all plans. Enterprises that need secret protection capabilities for private repositories should review [GitHub Advanced Security](https://github.com/security/advanced-security). Not only does it include secret protection, it also provides advanced static analysis, composition, analysis, and enterprise tools to manage your entire AppSec pipeline and reduce your risk profile.
+Secret protection is available **for free for public repositories** on all plans. Enterprises that need secret protection capabilities for private repositories should review [GitHub Advanced Security](https://github.com/security/advanced-security). Not only does it include secret protection, it also provides advanced static analysis, software composition analysis (SCA), and enterprise tools to manage your entire AppSec pipeline and reduce your risk profile.
 
 ### :keyboard: Activity: Configure secret protection
 


### PR DESCRIPTION
I believe this section refers to Software Composition Analysis

### Summary

- comma at the wrong place `composition, analysis`
- also add SCA as often used acronym for software composition analysis

### Changes

- replaced `composition, analysis` with `software composition analysis (SCA)`

Closes: #14 

I was not sure if it's okay to link wikipedia's SCA article, so didn't do that.

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
